### PR TITLE
Fix use of jQuery to allow for the 1.x branch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/components/backbone.git"
   },
   "dependencies": {
-    "jquery": "~2.0.3",
+    "jquery": "1.x || ~2.0.0",
     "underscore": "~1.4.4"
   },
   "version": "1.0.0",


### PR DESCRIPTION
This fixes #2 and was suggested by @paulmillr.
